### PR TITLE
Fix last_seqno check when timestamping is not enabled

### DIFF
--- a/PlutoSDR_RXStreamerIPGadget.cpp
+++ b/PlutoSDR_RXStreamerIPGadget.cpp
@@ -431,12 +431,8 @@ void rx_streamer_ip_gadget::thread_func(uint32_t curr_enabled_channels, uint32_t
 			block_index = 0;
 			block_count = hdr.block_count;
 
-			/* Is timestamping enabled? */
-			if (timestamp_every)
-			{
-				/* Yes, copy timestamp from header to working data */
-				last_seqno = hdr.seqno;
-			}
+			/* Copy timestamp from header to working data */
+			last_seqno = hdr.seqno;
 		}
 		else
 		{


### PR DESCRIPTION
When timestamping is not enabled, last_seqno is not updated, and the following check fails all the time:

PlutoSDR_RXStreamerIPGadget.cpp:440:

```
			if (	(block_index != hdr.block_index)
				 || (block_count != hdr.block_count)
				 || (last_seqno != hdr.seqno)
			   )
```